### PR TITLE
Bootstrap error class is called alert-danger, not alert-error

### DIFF
--- a/src/directives/flash-alert-directive.js
+++ b/src/directives/flash-alert-directive.js
@@ -33,7 +33,7 @@
                 function removeAlertClasses() {
                     element.removeClass('alert-info');
                     element.removeClass('alert-warn');
-                    element.removeClass('alert-error');
+                    element.removeClass('alert-danger');
                     element.removeClass('alert-success');
                 }
 

--- a/src/services/flash-service.js
+++ b/src/services/flash-service.js
@@ -75,7 +75,7 @@
             },
             set: function (message) {
                 _error = message;
-                _type = 'error';
+                _type = 'danger';
                 _notify(_type, message);
             }
         });


### PR DESCRIPTION
See http://getbootstrap.com/components/#alerts.

This is a quick fix. It might be better to consistently rename all occurrences of "error".
