### PR TITLE
Fix for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
     "description": "Flash messages for Angular Js",
     "version": "0.1.12",
     "main": [
-        "dist/angular-flash.min.js",
         "dist/angular-flash.js"
     ],
     "ignore": [


### PR DESCRIPTION
Currently main had two entries of angular-flash which is wrong since grunt will lookup main and automatically add all entries in main to your index.html. if angular-flash exists twice it will be twice in your application.
