### PR TITLE
Fix for messages disappearing during the destroy event 

### DIFF
--- a/src/directives/flash-alert-directive.js
+++ b/src/directives/flash-alert-directive.js
@@ -26,8 +26,11 @@
                 };
 
                 $scope.$on('$destroy', function () {
-                    flash.clean();
-                    flash.unsubscribe(subscribeHandle);
+                    if(flash.cleanOnReload) {
+                        flash.clean();
+                        flash.unsubscribe(subscribeHandle);
+                    }
+		    flash.cleanOnReload = true;
                 });
 
                 function removeAlertClasses() {

--- a/src/services/flash-service.js
+++ b/src/services/flash-service.js
@@ -23,6 +23,7 @@
         var _warn;
         var _error;
         var _type;
+	var _cleanOnReload = true;
 
         function _notify(type, message) {
             angular.forEach(_options.subscribers, function (subscriber) {
@@ -127,6 +128,15 @@
         Object.defineProperty(this, 'id', {
             get: function () {
                 return _options.id;
+            }
+        });
+
+        Object.defineProperty(this, 'cleanOnReload', {
+            get: function () {
+                return _cleanOnReload;
+            },
+            set: function (cleanOnReload) {
+                _cleanOnReload = cleanOnReload;
             }
         });
     };


### PR DESCRIPTION
It is (in part) related to https://github.com/wmluke/angular-flash/issues/28.
